### PR TITLE
Bugfix: Allowed the tool to skip deleted video files. 

### DIFF
--- a/src/immich_tiktok_remover.py
+++ b/src/immich_tiktok_remover.py
@@ -54,7 +54,10 @@ if not config["outputAllVideos"]:
 for video in immichVideos:
     videoId = video.get("id")
     if verifyVideoNameAndDate(video.get("originalFileName"), video.get("fileCreatedAt")):
-        is_tiktok = processVideo(serveVideo(videoId))
+        try:
+            is_tiktok = processVideo(serveVideo(videoId))
+        except:
+            is_tiktok = -1
         if is_tiktok == 1:
             detectedTikTokVideos += 1
 


### PR DESCRIPTION
When this tool is run and the video file itself has been deleted, but is still in the immich database, this tool will fail to process any other videos. This commit allows the tool to continue with the rest of the videos instead of erroring on a NoneType.

Before fix:
[
![Screenshot 2025-05-30 014837](https://github.com/user-attachments/assets/acbdb274-4b92-4e68-8d8f-cf950d385c26)
](url)

After fix:
![Screenshot 2025-05-30 014731](https://github.com/user-attachments/assets/1878038b-b681-4aef-9c81-0ded8d46e700)
