### PR TITLE
Fixed typo in the env file check

### DIFF
--- a/src/immich_tiktok_remover.py
+++ b/src/immich_tiktok_remover.py
@@ -28,7 +28,7 @@ else:
     try:
         pingServer()
     except Exception as e:
-        print("Error while trying to connect to Immich. Mabey delete .env file from directory and run script again?")
+        print("Error while trying to connect to Immich. Maybe delete the .env file from the working directory and run script again?")
         sys.exit()
 
 # Get the configuration parameters


### PR DESCRIPTION
Fixed a typo in the .env file check and made error more readable