### PR TITLE
isArchived has been deprecated in favor of "visibility": "archive"

### DIFF
--- a/src/immich.py
+++ b/src/immich.py
@@ -154,7 +154,7 @@ def archiveVideo(id: str):
 
     payload = {
     "ids": [id],
-    "isArchived": True,
+    "visibility": "archive"
     }
     headers = {
         'x-api-key': API_KEY,


### PR DESCRIPTION
Switched 
```py
payload = {
    "ids": [id],
    "isArchived": True,
    }
```

to 
```py
payload = {
        "ids": [id],
        "visibility": "archive"
    }
```
in the archiveVideo function, as `"isArchived": True` has been deprecated and no longer works.
Tested on Immich v2.7.5